### PR TITLE
Disable MQTTsetMQTT and MQTT_HTTPS_FW_UPDATE to allow OTA for Avatto …

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -756,6 +756,7 @@ board_build.flash_mode = dout
 [env:avatto-bakeey-ir]
 platform = ${com.esp8266_platform}
 board = esp01_1m
+board_build.ldscript = eagle.flash.1m64.ld
 lib_deps =
   ${com-esp.lib_deps}
   ${libraries.irremoteesp}
@@ -767,6 +768,8 @@ build_flags =
   '-DLED_SEND_RECEIVE=4'
   '-DIR_EMITTER_GPIO=14'
   '-DIR_RECEIVER_GPIO=5'
+  '-UMQTTsetMQTT' ;We remove this function to have sufficient FLASH available for OTA, you should also use ESPWifiManualSetup and 'board_build.ldscript = eagle.flash.1m64.ld' to save flash memory and have OTA working
+  '-UMQTT_HTTPS_FW_UPDATE' ;We remove this function to have sufficient FLASH available for OTA, you should also use ESPWifiManualSetup and 'board_build.ldscript = eagle.flash.1m64.ld' to save flash memory and have OTA working
   '-DGateway_Name="OpenMQTTGateway_AVATTO_IR"'
 board_build.flash_mode = dout
 


### PR DESCRIPTION
…Bakery IR

Trying to update my Avattos with the currently released 0.9.8 I found that OTA wasn't possible any longer as the build was now to large

0.9.8
Checking size .pio/build/avatto-bakeey-ir/firmware.elf
Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
RAM:   [====      ]  42.4% (used 34772 bytes from 81920 bytes)
Flash: [======    ]  55.2% (used 528716 bytes from 958448 bytes)

this goes back to 0.9.7, where WiFi, MQTT and firmware update was introduced over MQTT commands

0.9.7
Checking size .pio/build/avatto-bakeey-ir/firmware.elf
Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
RAM:   [====      ]  42.4% (used 34772 bytes from 81920 bytes)
Flash: [======    ]  55.2% (used 528716 bytes from 958448 bytes)

Going back to building 0.9.6 I was able to OTA update again with the much smaller build

0.9.6
Checking size .pio/build/avatto-bakeey-ir/firmware.elf
Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
RAM:   [====      ]  39.7% (used 32512 bytes from 81920 bytes)
Flash: [====      ]  41.4% (used 396804 bytes from 958448 bytes)

Building 0.9.8 with the flags brings the build back to OTAable size

0.9.8 with
	'-UMQTTsetMQTT'
	'-UMQTT_HTTPS_FW_UPDATE'
Checking size .pio/build/avatto-bakeey-ir/firmware.elf
Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
RAM:   [====      ]  39.9% (used 32684 bytes from 81920 bytes)
Flash: [====      ]  42.3% (used 405024 bytes from 958448 bytes)

Similar to the flag setting in [env:rfbridge]

I'm not even sure if MQTT_HTTPS_FW_UPDATE would even work on the Avatto, with the limited flash memory. 

Should we also add

board_build.ldscript = eagle.flash.1m64.ld

as a default, as it's required for OTA updates on the Avattos as discussed in https://github.com/1technophile/OpenMQTTGateway/issues/763#issuecomment-698864712 ?

## Description:


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
